### PR TITLE
fixed: Table fields should be surrounded by ` to avoid conflicts with keywords

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -14,82 +14,82 @@ func TestBuilderCond(t *testing.T) {
 	}{
 		{
 			Eq{"a": 1}.And(Like{"b", "c"}).Or(Eq{"a": 2}.And(Like{"b", "g"})),
-			"(a=? AND b LIKE ?) OR (a=? AND b LIKE ?)",
+			"(`a`=? AND `b` LIKE ?) OR (`a`=? AND `b` LIKE ?)",
 			[]interface{}{1, "%c%", 2, "%g%"},
 		},
 		{
 			Eq{"a": 1}.Or(Like{"b", "c"}).And(Eq{"a": 2}.Or(Like{"b", "g"})),
-			"(a=? OR b LIKE ?) AND (a=? OR b LIKE ?)",
+			"(`a`=? OR `b` LIKE ?) AND (`a`=? OR `b` LIKE ?)",
 			[]interface{}{1, "%c%", 2, "%g%"},
 		},
 		{
 			Eq{"d": []string{"e", "f"}},
-			"d IN (?,?)",
+			"`d` IN (?,?)",
 			[]interface{}{"e", "f"},
 		},
 		{
 			Neq{"d": []string{"e", "f"}},
-			"d NOT IN (?,?)",
+			"`d` NOT IN (?,?)",
 			[]interface{}{"e", "f"},
 		},
 		{
 			Lt{"d": 3},
-			"d<?",
+			"`d`<?",
 			[]interface{}{3},
 		},
 		{
 			Lte{"d": 3},
-			"d<=?",
+			"`d`<=?",
 			[]interface{}{3},
 		},
 		{
 			Gt{"d": 3},
-			"d>?",
+			"`d`>?",
 			[]interface{}{3},
 		},
 		{
 			Gte{"d": 3},
-			"d>=?",
+			"`d`>=?",
 			[]interface{}{3},
 		},
 		{
 			Between{"d", 0, 2},
-			"d BETWEEN ? AND ?",
+			"`d` BETWEEN ? AND ?",
 			[]interface{}{0, 2},
 		},
 		{
 			IsNull{"d"},
-			"d IS NULL",
+			"`d` IS NULL",
 			[]interface{}{},
 		},
 		{
 			NotIn("a", 1, 2).And(NotIn("b", "c", "d")),
-			"a NOT IN (?,?) AND b NOT IN (?,?)",
+			"`a` NOT IN (?,?) AND `b` NOT IN (?,?)",
 			[]interface{}{1, 2, "c", "d"},
 		},
 		{
 			In("a", 1, 2).Or(In("b", "c", "d")),
-			"a IN (?,?) OR b IN (?,?)",
+			"`a` IN (?,?) OR `b` IN (?,?)",
 			[]interface{}{1, 2, "c", "d"},
 		},
 		{
 			In("a", []int{1, 2}).Or(In("b", []string{"c", "d"})),
-			"a IN (?,?) OR b IN (?,?)",
+			"`a` IN (?,?) OR `b` IN (?,?)",
 			[]interface{}{1, 2, "c", "d"},
 		},
 		{
 			In("a", Expr("select id from x where name > ?", "b")),
-			"a IN (select id from x where name > ?)",
+			"`a` IN (select id from x where name > ?)",
 			[]interface{}{"b"},
 		},
 		{
 			NotIn("a", Expr("select id from x where name > ?", "b")),
-			"a NOT IN (select id from x where name > ?)",
+			"`a` NOT IN (select id from x where name > ?)",
 			[]interface{}{"b"},
 		},
 		{
 			Or(Eq{"a": 1, "b": 2}, Eq{"c": 3, "d": 4}),
-			"(a=? AND b=?) OR (c=? AND d=?)",
+			"(`a`=? AND `b`=?) OR (`c`=? AND `d`=?)",
 			[]interface{}{1, 2, 3, 4},
 		},
 	}

--- a/cond_between.go
+++ b/cond_between.go
@@ -12,7 +12,7 @@ type Between struct {
 var _ Cond = Between{}
 
 func (between Between) WriteTo(w Writer) error {
-	if _, err := fmt.Fprintf(w, "%s BETWEEN ? AND ?", between.Col); err != nil {
+	if _, err := fmt.Fprintf(w, "`%s` BETWEEN ? AND ?", between.Col); err != nil {
 		return err
 	}
 	w.Append(between.LessVal, between.MoreVal)

--- a/cond_compare.go
+++ b/cond_compare.go
@@ -9,7 +9,7 @@ func WriteMap(w Writer, data map[string]interface{}, op string) error {
 	for k, v := range data {
 		switch v.(type) {
 		case expr:
-			if _, err := fmt.Fprintf(w, "%s%s(", k, op); err != nil {
+			if _, err := fmt.Fprintf(w, "`%s`%s(", k, op); err != nil {
 				return err
 			}
 
@@ -21,7 +21,7 @@ func WriteMap(w Writer, data map[string]interface{}, op string) error {
 				return err
 			}
 		case *Builder:
-			if _, err := fmt.Fprintf(w, "%s%s(", k, op); err != nil {
+			if _, err := fmt.Fprintf(w, "`%s`%s(", k, op); err != nil {
 				return err
 			}
 
@@ -33,7 +33,7 @@ func WriteMap(w Writer, data map[string]interface{}, op string) error {
 				return err
 			}
 		default:
-			if _, err := fmt.Fprintf(w, "%s%s?", k, op); err != nil {
+			if _, err := fmt.Fprintf(w, "`%s`%s?", k, op); err != nil {
 				return err
 			}
 			args = append(args, v)

--- a/cond_eq.go
+++ b/cond_eq.go
@@ -19,7 +19,7 @@ func (eq Eq) opWriteTo(op string, w Writer) error {
 				return err
 			}
 		case expr:
-			if _, err := fmt.Fprintf(w, "%s=(", k); err != nil {
+			if _, err := fmt.Fprintf(w, "`%s`=(", k); err != nil {
 				return err
 			}
 
@@ -31,7 +31,7 @@ func (eq Eq) opWriteTo(op string, w Writer) error {
 				return err
 			}
 		case *Builder:
-			if _, err := fmt.Fprintf(w, "%s=(", k); err != nil {
+			if _, err := fmt.Fprintf(w, "`%s`=(", k); err != nil {
 				return err
 			}
 
@@ -43,17 +43,17 @@ func (eq Eq) opWriteTo(op string, w Writer) error {
 				return err
 			}
 		case Incr:
-			if _, err := fmt.Fprintf(w, "%s=%s+?", k, k); err != nil {
+			if _, err := fmt.Fprintf(w, "`%s`=%s+?", k, k); err != nil {
 				return err
 			}
 			w.Append(int(v.(Incr)))
 		case Decr:
-			if _, err := fmt.Fprintf(w, "%s=%s-?", k, k); err != nil {
+			if _, err := fmt.Fprintf(w, "`%s`=%s-?", k, k); err != nil {
 				return err
 			}
 			w.Append(int(v.(Decr)))
 		default:
-			if _, err := fmt.Fprintf(w, "%s=?", k); err != nil {
+			if _, err := fmt.Fprintf(w, "`%s`=?", k); err != nil {
 				return err
 			}
 			w.Append(v)

--- a/cond_in.go
+++ b/cond_in.go
@@ -28,7 +28,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -40,7 +40,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -52,7 +52,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -64,7 +64,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -76,7 +76,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -88,7 +88,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -100,7 +100,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -112,7 +112,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -124,7 +124,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -136,7 +136,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -148,7 +148,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -160,13 +160,13 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		w.Append(vals...)
 	case expr:
 		val := condIn.vals[0].(expr)
-		if _, err := fmt.Fprintf(w, "%s IN (", condIn.col); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (", condIn.col); err != nil {
 			return err
 		}
 		if err := val.WriteTo(w); err != nil {
@@ -177,7 +177,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 		}
 	case *Builder:
 		bd := condIn.vals[0].(*Builder)
-		if _, err := fmt.Fprintf(w, "%s IN (", condIn.col); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (", condIn.col); err != nil {
 			return err
 		}
 		if err := bd.WriteTo(w); err != nil {
@@ -191,7 +191,7 @@ func (condIn condIn) WriteTo(w Writer) error {
 			return ErrNoInConditions
 		}
 		questionMark := strings.Repeat("?,", len(condIn.vals))
-		if _, err := fmt.Fprintf(w, "%s IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` IN (%s)", condIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		w.Append(condIn.vals...)

--- a/cond_like.go
+++ b/cond_like.go
@@ -7,7 +7,7 @@ type Like [2]string
 var _ Cond = Like{"", ""}
 
 func (like Like) WriteTo(w Writer) error {
-	if _, err := fmt.Fprintf(w, "%s LIKE ?", like[0]); err != nil {
+	if _, err := fmt.Fprintf(w, "`%s` LIKE ?", like[0]); err != nil {
 		return err
 	}
 	w.Append("%" + like[1] + "%")

--- a/cond_neq.go
+++ b/cond_neq.go
@@ -16,7 +16,7 @@ func (neq Neq) WriteTo(w Writer) error {
 				return err
 			}
 		case expr:
-			if _, err := fmt.Fprintf(w, "%s<>(", k); err != nil {
+			if _, err := fmt.Fprintf(w, "`%s`<>(", k); err != nil {
 				return err
 			}
 
@@ -28,7 +28,7 @@ func (neq Neq) WriteTo(w Writer) error {
 				return err
 			}
 		case *Builder:
-			if _, err := fmt.Fprintf(w, "%s<>(", k); err != nil {
+			if _, err := fmt.Fprintf(w, "`%s`<>(", k); err != nil {
 				return err
 			}
 
@@ -40,7 +40,7 @@ func (neq Neq) WriteTo(w Writer) error {
 				return err
 			}
 		default:
-			if _, err := fmt.Fprintf(w, "%s<>?", k); err != nil {
+			if _, err := fmt.Fprintf(w, "`%s`<>?", k); err != nil {
 				return err
 			}
 			args = append(args, v)

--- a/cond_notin.go
+++ b/cond_notin.go
@@ -25,7 +25,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -37,7 +37,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -49,7 +49,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -61,7 +61,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -73,7 +73,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -85,7 +85,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -97,7 +97,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -109,7 +109,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -121,7 +121,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -133,7 +133,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -145,7 +145,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		for _, val := range vals {
@@ -157,13 +157,13 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 			return ErrNoNotInConditions
 		}
 		questionMark := strings.Repeat("?,", len(vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		w.Append(vals...)
 	case expr:
 		val := condNotIn.vals[0].(expr)
-		if _, err := fmt.Fprintf(w, "%s NOT IN (", condNotIn.col); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (", condNotIn.col); err != nil {
 			return err
 		}
 		if err := val.WriteTo(w); err != nil {
@@ -174,7 +174,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 		}
 	case *Builder:
 		val := condNotIn.vals[0].(*Builder)
-		if _, err := fmt.Fprintf(w, "%s NOT IN (", condNotIn.col); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (", condNotIn.col); err != nil {
 			return err
 		}
 		if err := val.WriteTo(w); err != nil {
@@ -185,7 +185,7 @@ func (condNotIn condNotIn) WriteTo(w Writer) error {
 		}
 	default:
 		questionMark := strings.Repeat("?,", len(condNotIn.vals))
-		if _, err := fmt.Fprintf(w, "%s NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
+		if _, err := fmt.Fprintf(w, "`%s` NOT IN (%s)", condNotIn.col, questionMark[:len(questionMark)-1]); err != nil {
 			return err
 		}
 		w.Append(condNotIn.vals...)

--- a/cond_null.go
+++ b/cond_null.go
@@ -8,7 +8,7 @@ type IsNull [1]string
 var _ Cond = IsNull{""}
 
 func (isNull IsNull) WriteTo(w Writer) error {
-	_, err := fmt.Fprintf(w, "%s IS NULL", isNull[0])
+	_, err := fmt.Fprintf(w, "`%s` IS NULL", isNull[0])
 	return err
 }
 
@@ -30,7 +30,7 @@ type NotNull [1]string
 var _ Cond = NotNull{""}
 
 func (notNull NotNull) WriteTo(w Writer) error {
-	_, err := fmt.Fprintf(w, "%s IS NOT NULL", notNull[0])
+	_, err := fmt.Fprintf(w, "`%s` IS NOT NULL", notNull[0])
 	return err
 }
 


### PR DESCRIPTION
fixed: Table fields should be surrounded by ` to avoid conflicts with keywords