### PR TITLE
Allow Other Types of Pattern Matching in LIKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,12 @@ sql, args, _ := ToSQL(Lt{"a", 1}.Or(Lte{"b", 2}))
 ```Go
 import . "github.com/go-xorm/builder"
 
-sql, args, _ := ToSQL(Like{"a", "c"})
-// a LIKE ? [%c%]
+sql, args, _ := ToSQL(Like{"a", "%c%"})
+// a LIKE '?' [%c%]
+sql, args, _ := ToSQL(Like{"a", "%c"})
+// a LIKE '?' [%c]
+sql, args, _ := ToSQL(Like{"a", "c%"})
+// a LIKE '?' [c%]
 ```
 
 * `Expr` you can customerize your sql with `Expr`
@@ -133,8 +137,8 @@ sql, args, _ := ToSQL(NotNull{"b"})
 ```Go
 import . "github.com/go-xorm/builder"
 
-sql, args, _ := ToSQL(And(Eq{"a":1}, Like{"b", "c"}, Neq{"d", 2}))
-// a=? AND b LIKE ? AND d<>? [1, %c%, 2]
+sql, args, _ := ToSQL(And(Eq{"a":1}, Like{"b", "%c%"}, Neq{"d", 2}))
+// a=? AND b LIKE '?' AND d<>? [1, %c%, 2]
 ```
 
 * `Or(conds ...Cond)`, Or can connect one or more conditions via Or
@@ -142,10 +146,10 @@ sql, args, _ := ToSQL(And(Eq{"a":1}, Like{"b", "c"}, Neq{"d", 2}))
 ```Go
 import . "github.com/go-xorm/builder"
 
-sql, args, _ := ToSQL(Or(Eq{"a":1}, Like{"b", "c"}, Neq{"d", 2}))
-// a=? OR b LIKE ? OR d<>? [1, %c%, 2]
-sql, args, _ := ToSQL(Or(Eq{"a":1}, And(Like{"b", "c"}, Neq{"d", 2})))
-// a=? OR (b LIKE ? AND d<>?) [1, %c%, 2]
+sql, args, _ := ToSQL(Or(Eq{"a":1}, Like{"b", "%c%"}, Neq{"d", 2}))
+// a=? OR b LIKE '?' OR d<>? [1, %c%, 2]
+sql, args, _ := ToSQL(Or(Eq{"a":1}, And(Like{"b", "%c%"}, Neq{"d", 2})))
+// a=? OR (b LIKE '?' AND d<>?) [1, %c%, 2]
 ```
 
 * `Between`

--- a/builder_test.go
+++ b/builder_test.go
@@ -13,14 +13,14 @@ func TestBuilderCond(t *testing.T) {
 		args []interface{}
 	}{
 		{
-			Eq{"a": 1}.And(Like{"b", "c"}).Or(Eq{"a": 2}.And(Like{"b", "g"})),
-			"(a=? AND b LIKE ?) OR (a=? AND b LIKE ?)",
-			[]interface{}{1, "%c%", 2, "%g%"},
+			Eq{"a": 1}.And(Like{"b", "%c%"}).Or(Eq{"a": 2}.And(Like{"b", "%g%"})),
+			"(a=? AND b LIKE '%c%') OR (a=? AND b LIKE '%g%')",
+			[]interface{}{1, 2},
 		},
 		{
-			Eq{"a": 1}.Or(Like{"b", "c"}).And(Eq{"a": 2}.Or(Like{"b", "g"})),
-			"(a=? OR b LIKE ?) AND (a=? OR b LIKE ?)",
-			[]interface{}{1, "%c%", 2, "%g%"},
+			Eq{"a": 1}.Or(Like{"b", "%c%"}).And(Eq{"a": 2}.Or(Like{"b", "%g%"})),
+			"(a=? OR b LIKE '%c%') AND (a=? OR b LIKE '%g%')",
+			[]interface{}{1, 2},
 		},
 		{
 			Eq{"d": []string{"e", "f"}},

--- a/cond_like.go
+++ b/cond_like.go
@@ -7,10 +7,9 @@ type Like [2]string
 var _ Cond = Like{"", ""}
 
 func (like Like) WriteTo(w Writer) error {
-	if _, err := fmt.Fprintf(w, "%s LIKE ?", like[0]); err != nil {
+	if _, err := fmt.Fprintf(w, "%s LIKE '%s'", like[0], like[1]); err != nil {
 		return err
 	}
-	w.Append("%" + like[1] + "%")
 	return nil
 }
 

--- a/doc.go
+++ b/doc.go
@@ -59,10 +59,14 @@ WARNNING: Currently, only query conditions are supported. Below is the supported
 
     import . "github.com/go-xorm/builder"
 
-    sql, args, _ := ToSQL(Like{"a", "c"})
-    // a LIKE ? [%c%]
+    sql, args, _ := ToSQL(Like{"a", "%c%"})
+    // a LIKE '?' [%c%]
+	sql, args, _ := ToSQL(Like{"a", "%c"})
+	// a LIKE '?' [%c]
+	sql, args, _ := ToSQL(Like{"a", "c%"})
+	// a LIKE '?' [c%]
 
-5. Expr you can customerize your sql with Expr
+5. Expr you can customize your sql with Expr
 
     import . "github.com/go-xorm/builder"
 
@@ -91,21 +95,21 @@ WARNNING: Currently, only query conditions are supported. Below is the supported
     sql, args, _ := ToSQL(NotNull{"b"})
      // b IS NOT NULL []
 
-8. And(conds ...Cond), And can connect one or more condtions via AND
+8. And(conds ...Cond), And can connect one or more conditions via AND
 
     import . "github.com/go-xorm/builder"
 
-    sql, args, _ := ToSQL(And(Eq{"a":1}, Like{"b", "c"}, Neq{"d", 2}))
-    // a=? AND b LIKE ? AND d<>? [1, %c%, 2]
+    sql, args, _ := ToSQL(And(Eq{"a":1}, Like{"b", "%c%"}, Neq{"d", 2}))
+    // a=? AND b LIKE '?' AND d<>? [1, %c%, 2]
 
 9. Or(conds ...Cond), Or can connect one or more conditions via Or
 
     import . "github.com/go-xorm/builder"
 
-    sql, args, _ := ToSQL(Or(Eq{"a":1}, Like{"b", "c"}, Neq{"d", 2}))
-    // a=? OR b LIKE ? OR d<>? [1, %c%, 2]
-    sql, args, _ := ToSQL(Or(Eq{"a":1}, And(Like{"b", "c"}, Neq{"d", 2})))
-    // a=? OR (b LIKE ? AND d<>?) [1, %c%, 2]
+    sql, args, _ := ToSQL(Or(Eq{"a":1}, Like{"b", "%c%"}, Neq{"d", 2}))
+    // a=? OR b LIKE '?' OR d<>? [1, %c%, 2]
+    sql, args, _ := ToSQL(Or(Eq{"a":1}, And(Like{"b", "%c%"}, Neq{"d", 2})))
+    // a=? OR (b LIKE '?' AND d<>?) [1, %c%, 2]
 
 10. Between
 


### PR DESCRIPTION
Previously, all LIKE clauses had to follow this pattern matching scheme:
```sql
select * from a where b LIKE %somestring%
```
This limits the power of LIKE.  For example, both MySQL and PostgreSQL have pattern matching such as the following:
```sql
select * from a where b LIKE 'some%' --begins with some
select * from a where b LIKE '%string' --ends with string
```
This PR gives the user greater power in determining which pattern they would like to use for LIKE.
NOTE: This does break any existing usage of go-xorm/builder that relies on it to add the surrounding % %; however the LIKE clause was not being generated correctly as 
```sql 
select * from a where b LIKE %somestring%
```
is not valid SQL, but this is:
```sql
select * from a where b LIKE '%somestring%'
```