### PR TITLE
Fix empty IN/NOT IN conditions

### DIFF
--- a/cond_in.go
+++ b/cond_in.go
@@ -23,10 +23,8 @@ func In(col string, values ...interface{}) Cond {
 }
 
 func (condIn condIn) handleBlank(w Writer) error {
-	if _, err := fmt.Fprintf(w, "%s IN ()", condIn.col); err != nil {
-		return err
-	}
-	return nil
+	_, err := fmt.Fprint(w, "0=1")
+	return err
 }
 
 func (condIn condIn) WriteTo(w Writer) error {

--- a/cond_notin.go
+++ b/cond_notin.go
@@ -20,10 +20,8 @@ func NotIn(col string, values ...interface{}) Cond {
 }
 
 func (condNotIn condNotIn) handleBlank(w Writer) error {
-	if _, err := fmt.Fprintf(w, "%s NOT IN ()", condNotIn.col); err != nil {
-		return err
-	}
-	return nil
+	_, err := fmt.Fprint(w, "0=0")
+	return err
 }
 
 func (condNotIn condNotIn) WriteTo(w Writer) error {


### PR DESCRIPTION
For empty `IN` clauses, xorm generates SQL of the form `<col> IN ()` (similarly for `NOT IN`). This is not accepted by either MySQL or PostgreSQL, and might as well be replaced with false (`0=1`) and true (`0=0`) conditions, respectively