### PR TITLE
Bugfix: do not add a where clause automatically for select

### DIFF
--- a/builder_select.go
+++ b/builder_select.go
@@ -45,6 +45,10 @@ func (b *Builder) selectWriteTo(w Writer) error {
 		}
 	}
 
+	if !b.cond.IsValid() {
+		return nil
+	}
+
 	if _, err := fmt.Fprint(w, " WHERE "); err != nil {
 		return err
 	}

--- a/builder_test.go
+++ b/builder_test.go
@@ -139,7 +139,13 @@ func TestBuilderCond(t *testing.T) {
 }
 
 func TestBuilderSelect(t *testing.T) {
-	sql, args, err := Select("c, d").From("table1").Where(Eq{"a": 1}).ToSQL()
+	sql, args, err := Select("c, d").From("table1").ToSQL()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(sql, args)
+
+	sql, args, err = Select("c, d").From("table1").Where(Eq{"a": 1}).ToSQL()
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
Reproduce:

```go
sql, args, err := builder.Select("id").From("table_b").ToSQL()
fmt.Println(sql)
fmt.Println(args)
fmt.Println(err)
```
Output:
```
SELECT id FROM table_b WHERE
[]
<nil>
```