### PR TITLE
Avoid random map iteration order to generate consistent SQL

### DIFF
--- a/builder_insert.go
+++ b/builder_insert.go
@@ -15,7 +15,7 @@ func (b *Builder) insertWriteTo(w Writer) error {
 		return errors.New("no table indicated")
 	}
 	if len(b.inserts) <= 0 {
-		return errors.New("no column to be update")
+		return errors.New("no column to be insert")
 	}
 
 	if _, err := fmt.Fprintf(w, "INSERT INTO %s (", b.tableName); err != nil {
@@ -26,7 +26,9 @@ func (b *Builder) insertWriteTo(w Writer) error {
 	var bs []byte
 	var valBuffer = bytes.NewBuffer(bs)
 	var i = 0
-	for col, value := range b.inserts {
+
+	for _, col := range b.inserts.sortedKeys() {
+		value := b.inserts[col]
 		fmt.Fprint(w, col)
 		if e, ok := value.(expr); ok {
 			fmt.Fprint(valBuffer, e.sql)

--- a/builder_test.go
+++ b/builder_test.go
@@ -129,6 +129,18 @@ func TestBuilderCond(t *testing.T) {
 		}
 		fmt.Println(sql)
 
+		for i := 0; i < 10; i++ {
+			sql2, _, err := ToSQL(k.cond)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if sql2 != sql {
+				t.Error("first ToSQL result", sql, "other ToSQL result", sql2)
+				return
+			}
+		}
+
 		if !(len(args) == 0 && len(k.args) == 0) {
 			if !reflect.DeepEqual(args, k.args) {
 				t.Error("want", k.args, "get", args)

--- a/builder_test.go
+++ b/builder_test.go
@@ -110,12 +110,11 @@ func TestBuilderCond(t *testing.T) {
 			"0=0",
 			[]interface{}{},
 		},
-		// FIXME: since map will not guarantee the sequence, this may be failed random
-		/*{
+		{
 			Or(Eq{"a": 1, "b": 2}, Eq{"c": 3, "d": 4}),
 			"(a=? AND b=?) OR (c=? AND d=?)",
 			[]interface{}{1, 2, 3, 4},
-		},*/
+		},
 	}
 
 	for _, k := range cases {
@@ -208,14 +207,14 @@ func TestSubquery(t *testing.T) {
 	subb := Select("id").From("table_b").Where(Eq{"b": "a"})
 	b := Select("a, b").From("table_a").Where(
 		Eq{
-			"id":   23,
 			"b_id": subb,
+			"id":   23,
 		},
 	)
 	sql, args, err := b.ToSQL()
 	assert.NoError(t, err)
-	assert.EqualValues(t, "SELECT a, b FROM table_a WHERE id=? AND b_id=(SELECT id FROM table_b WHERE b=?)", sql)
-	assert.EqualValues(t, []interface{}{23, "a"}, args)
+	assert.EqualValues(t, "SELECT a, b FROM table_a WHERE b_id=(SELECT id FROM table_b WHERE b=?) AND id=?", sql)
+	assert.EqualValues(t, []interface{}{"a", 23}, args)
 }
 
 // https://github.com/go-xorm/xorm/issues/820

--- a/cond_compare.go
+++ b/cond_compare.go
@@ -10,7 +10,13 @@ import "fmt"
 func WriteMap(w Writer, data map[string]interface{}, op string) error {
 	var args = make([]interface{}, 0, len(data))
 	var i = 0
-	for k, v := range data {
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+
+	for _, k := range keys {
+		v := data[k]
 		switch v.(type) {
 		case expr:
 			if _, err := fmt.Fprintf(w, "%s%s(", k, op); err != nil {

--- a/cond_eq.go
+++ b/cond_eq.go
@@ -4,7 +4,10 @@
 
 package builder
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // Incr implements a type used by Eq
 type Incr int
@@ -19,7 +22,8 @@ var _ Cond = Eq{}
 
 func (eq Eq) opWriteTo(op string, w Writer) error {
 	var i = 0
-	for k, v := range eq {
+	for _, k := range eq.sortedKeys() {
+		v := eq[k]
 		switch v.(type) {
 		case []int, []int64, []string, []int32, []int16, []int8, []uint, []uint64, []uint32, []uint16, []interface{}:
 			if err := In(k, v).WriteTo(w); err != nil {
@@ -93,4 +97,16 @@ func (eq Eq) Or(conds ...Cond) Cond {
 // IsValid tests if this Eq is valid
 func (eq Eq) IsValid() bool {
 	return len(eq) > 0
+}
+
+// sortedKeys returns all keys of this Eq sorted with sort.Strings.
+// It is used internally for consistent ordering when generating
+// SQL, see https://github.com/go-xorm/builder/issues/10
+func (eq Eq) sortedKeys() []string {
+	keys := make([]string, 0, len(eq))
+	for key := range eq {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }


### PR DESCRIPTION
This closes https://github.com/go-xorm/builder/issues/10 as discussed!

It also uncomments an old test, fixes an error message, and adds a test to make sure there are no regressions.