### PR TITLE
MsSQL Limits

### DIFF
--- a/builder_select.go
+++ b/builder_select.go
@@ -21,7 +21,7 @@ func (b *Builder) selectWriteTo(w Writer) error {
 
 	// perform limit before writing to writer when b.dialect between ORACLE and MSSQL
 	// this avoid a duplicate writing problem in simple limit query
-	if b.limitation != nil && (b.dialect == ORACLE || b.dialect == MSSQL) {
+	if b.limitation != nil && b.dialect == ORACLE {
 		return b.limitWriteTo(w)
 	}
 
@@ -115,6 +115,17 @@ func (b *Builder) selectWriteTo(w Writer) error {
 		if _, err := fmt.Fprint(w, " ORDER BY ", b.orderBy); err != nil {
 			return err
 		}
+
+		if b.limitation != nil && b.dialect == MSSQL {
+			if err := b.limitWriteTo(w); err != nil {
+				return err
+			}
+		}
+	}
+
+	// limit can only appear after an order by clause
+	if b.limitation != nil && b.dialect == MSSQL {
+		return ErrInvalidLimitation
 	}
 
 	if b.limitation != nil {


### PR DESCRIPTION
Not entirely sure how the previous implementation was supposed to work.
With SQL Server 2008 there is support for [OFFSET and FETCH clauses](https://docs.microsoft.com/en-us/sql/t-sql/queries/select-order-by-clause-transact-sql?view=sql-server-2017#using-offset-and-fetch-to-limit-the-rows-returned).